### PR TITLE
Update packages.json and index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const request = require('request-promise')
-const fs = require('fs-extra')
+const fsPromises = require('fs').promises;
 const iconv = require('iconv-lite')
 const JSSoup = require('jssoup').default
 
@@ -163,7 +163,7 @@ const getTimeTable = async (dept = undefined, type = '전공', isDebug = true, o
     }
     log(`파싱 완료!`)
     if(outputFile){
-      await fs.writeFile(outputFile, JSON.stringify(datas, null, 2))
+      await fsPromises.writeFile(outputFile, JSON.stringify(datas, null, 2))
       log(`파일 쓰기 완료!`)
     } 
     if(isDebug) console.timeEnd('parse')

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ const getTimeTable = async (dept = undefined, type = '전공', isDebug = true, o
     if(!html){
       throw new Error("네트워크가 연결되어있지 않거나 올바르지 않은 학과번호입니다. 사이트가 닫혀있을 수도 있습니다.")
     }
-    const soup = new JSSoup(iconv.decode(new Buffer(html), 'EUC-KR').toString())
+    const soup = new JSSoup(iconv.decode(Buffer.from(html), 'EUC-KR').toString())
     const tbody = soup.find('tbody')
 
     log('HTML 다운로드 완료')

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,16 +139,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      }
-    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -156,11 +146,6 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
-    },
-    "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "growl": {
       "version": "1.10.5",
@@ -204,11 +189,6 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "ip-regex": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
-    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -238,14 +218,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "requires": {
-        "graceful-fs": "^4.1.6"
-      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -361,22 +333,22 @@
       }
     },
     "request-promise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
-      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.4.tgz",
+      "integrity": "sha512-8wgMrvE546PzbR5WbYxUQogUnUDfM0S7QIFZMID+J73vdFARkFy+HElj4T+MWYhpXwlLp0EQ8Zoj8xUA0he4Vg==",
       "requires": {
         "bluebird": "^3.5.0",
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "^1.1.0",
-        "tough-cookie": ">=2.3.3"
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
       }
     },
     "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
       "requires": {
-        "lodash": "^4.13.1"
+        "lodash": "^4.17.11"
       }
     },
     "safe-buffer": {
@@ -411,11 +383,10 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "tough-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-      "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
-        "ip-regex": "^2.1.0",
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
       }
@@ -432,11 +403,6 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
-    "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,9 @@
   "author": "agrajak <korbots@gmail.com>",
   "license": "ISC",
   "dependencies": {
-    "fs-extra": "^7.0.1",
     "iconv-lite": "^0.4.24",
     "jssoup": "0.0.10",
     "request": "^2.88.0",
-    "request-promise": "^4.2.2",
-    "v-suggest": "^1.1.3"
+    "request-promise": "^4.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "agrajak <korbots@gmail.com>",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "iconv-lite": "^0.4.24",
     "jssoup": "0.0.10",


### PR DESCRIPTION
# ChangeLog

## Updated

- `request-promise`를 최신버전으로 업데이트함: 4.2.2 -> 4.2.4

## Fixed

- `packages.json`의 `license` 속성을 저장소에 표기된 라이선스로 수정함: ISC -> MIT
- [Deprecation Warning](https://nodejs.org/api/buffer.html#buffer_new_buffer_array) 수정; `new Buffer`

## Removed

- `fs-extra`와 `v-suggest`를 삭제함; `fs-extra`를 [fsPromises](https://nodejs.org/api/fs.html#fs_fspromises_writefile_file_data_options)로 교체함
